### PR TITLE
TWS-1287:  actions.runnerが起動していないのに`gh_ready=1`ラベルがついてしまって大量のVMが残ってしまうのを修正

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -266,8 +266,8 @@ function start_vm {
 	./svc.sh install && \\
 	./svc.sh start && \\
 	gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=1
-	# 3 days represents the max workflow runtime. This will shutdown the instance if everything else fails.
-	nohup sh -c \"sleep 3d && CLOUDSDK_CONFIG=/tmp gcloud --quiet compute instances delete ${VM_ID} --zone=${machine_zone}\" > /dev/null &
+	# self shutdown in 1 day.
+	nohup sh -c \"sleep 1d && CLOUDSDK_CONFIG=/tmp gcloud --quiet compute instances delete ${VM_ID} --zone=${machine_zone}\" > /dev/null &
   "
 
   if $actions_preinstalled ; then

--- a/action.sh
+++ b/action.sh
@@ -305,7 +305,7 @@ function start_vm {
 	# Ensure actions.runner service is active
 	#   it will shutdown the instance if actions.runner is not active
 	#   the instance will be shutdown in 1 day if actions runner is active even though the max workflow runtime is 3 days
-	if systemctl show actions.runner*${VM_ID}* -p ActiveState | grep 'ActiveState=' | head -1 | cut -f 2 -d '=' | grep 'active'; then
+	if systemctl show actions.runner* -p ActiveState | grep 'ActiveState=' | head -1 | cut -f 2 -d '=' | grep 'active'; then
 	  echo \"✅ Successfully started the GitHub Actions runner service.\";
 	  gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=1;
 	  nohup sh -c \"sleep 1d && CLOUDSDK_CONFIG=/tmp gcloud --quiet compute instances delete ${VM_ID} --zone=${machine_zone}\" > /dev/null &

--- a/action.sh
+++ b/action.sh
@@ -180,7 +180,42 @@ function start_vm {
       jq -r .token)
   echo "✅ Successfully got the GitHub Runner registration token"
 
-  VM_ID="gce-gh-runner-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}"
+  # GCE VM label values requirements:
+  # - can contain only lowercase letters, numeric characters, underscores, and dashes
+  # - have a maximum length of 63 characters
+  # ref: https://cloud.google.com/compute/docs/labeling-resources#requirements
+  #
+  # Github's requirements:
+  # - username/organization name
+  #   - Max length: 39 characters
+  #   - All characters must be either a hyphen (-) or alphanumeric
+  # - repository name
+  #   - Max length: 100 code points
+  #   - All code points must be either a hyphen (-), an underscore (_), a period (.), 
+  #     or an ASCII alphanumeric code point
+  # ref: https://github.com/dead-claudia/github-limits
+  function truncate_to_label {
+    local in="${1}"
+    in="${in:0:63}"                              # ensure max length
+    in="${in//./_}"                              # replace '.' with '_'
+    in=$(tr '[:upper:]' '[:lower:]' <<< "${in}") # convert to lower
+    echo -n "${in}"
+  }
+  gh_repo_owner="$(truncate_to_label "${GITHUB_REPOSITORY_OWNER}")"
+  gh_repo="$(truncate_to_label "${GITHUB_REPOSITORY##*/}")"
+  gh_job="$(truncate_to_label "${GITHUB_JOB}")"
+  gh_run_id="${GITHUB_RUN_ID}"
+  gh_run_attempt="${GITHUB_RUN_ATTEMPT}"
+
+  VM_ID="gce-gh-runner-${gh_repo}-${GITHUB_RUN_ID}-${gh_job}-${GITHUB_RUN_ATTEMPT}"
+  if [ ${#VM_ID} -gt 63 ]; then
+    echo "VM_ID is too long: ${VM_ID}. It must be 63 characters or less."
+    VM_ID_PREFIX="${VM_ID:0:55}"
+    VM_ID_SUFFIX=$(echo ${VM_ID} | md5sum | cut -c 1-7)
+    VM_ID="${VM_ID_PREFIX}-${VM_ID_SUFFIX}"
+    echo "VM_ID is truncated: ${VM_ID}."
+  fi
+
   service_account_flag=$([[ -z "${runner_service_account}" ]] || echo "--service-account=${runner_service_account}")
   image_project_flag=$([[ -z "${image_project}" ]] || echo "--image-project=${image_project}")
   image_flag=$([[ -z "${image}" ]] || echo "--image=${image}")
@@ -300,31 +335,6 @@ function start_vm {
       $startup_script"
     fi
   fi
-  
-  # GCE VM label values requirements:
-  # - can contain only lowercase letters, numeric characters, underscores, and dashes
-  # - have a maximum length of 63 characters
-  # ref: https://cloud.google.com/compute/docs/labeling-resources#requirements
-  #
-  # Github's requirements:
-  # - username/organization name
-  #   - Max length: 39 characters
-  #   - All characters must be either a hyphen (-) or alphanumeric
-  # - repository name
-  #   - Max length: 100 code points
-  #   - All code points must be either a hyphen (-), an underscore (_), a period (.), 
-  #     or an ASCII alphanumeric code point
-  # ref: https://github.com/dead-claudia/github-limits
-  function truncate_to_label {
-    local in="${1}"
-    in="${in:0:63}"                              # ensure max length
-    in="${in//./_}"                              # replace '.' with '_'
-    in=$(tr '[:upper:]' '[:lower:]' <<< "${in}") # convert to lower
-    echo -n "${in}"
-  }
-  gh_repo_owner="$(truncate_to_label "${GITHUB_REPOSITORY_OWNER}")"
-  gh_repo="$(truncate_to_label "${GITHUB_REPOSITORY##*/}")"
-  gh_run_id="${GITHUB_RUN_ID}"
 
   gcloud compute instances create ${VM_ID} \
     --zone=${machine_zone} \
@@ -342,7 +352,7 @@ function start_vm {
     ${accelerator} \
     ${maintenance_policy_flag} \
     ${instance_termination_action_flag} \
-    --labels=gh_ready=0,gh_repo_owner="${gh_repo_owner}",gh_repo="${gh_repo}",gh_run_id="${gh_run_id}" \
+    --labels=gh_ready=0,gh_repo_owner="${gh_repo_owner}",gh_repo="${gh_repo}",gh_run_id="${gh_run_id}",gh_run_attempt="${gh_run_attempt}",gh_job="${gh_job}" \
     --metadata-from-file=shutdown-script=/tmp/shutdown_script.sh \
     --metadata=startup-script="$startup_script" \
     && echo "label=${VM_ID}" >> $GITHUB_OUTPUT

--- a/action.sh
+++ b/action.sh
@@ -296,13 +296,23 @@ function start_vm {
 
 	# See: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job
 	echo "ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/usr/bin/gce_runner_shutdown.sh" >.env
+	
 	gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=0 && \\
 	RUNNER_ALLOW_RUNASROOT=1 ./config.sh --url https://github.com/${GITHUB_REPOSITORY} --token ${RUNNER_TOKEN} --labels ${VM_ID} --unattended ${ephemeral_flag} --disableupdate && \\
 	./svc.sh install && \\
-	./svc.sh start && \\
-	gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=1
-	# self shutdown in 1 day.
-	nohup sh -c \"sleep 1d && CLOUDSDK_CONFIG=/tmp gcloud --quiet compute instances delete ${VM_ID} --zone=${machine_zone}\" > /dev/null &
+	./svc.sh start
+
+	# Ensure actions.runner service is active
+	# if actions.runner is not active, it will shutdown the instance
+	if systemctl show actions.runner*${VM_ID}* -p ActiveState | grep 'ActiveState=' | head -1 | cut -f 2 -d '=' | grep 'active'; then
+	  echo "✅ Successfully started the GitHub Actions runner service."
+	  gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=1
+	  # self-shutdown in 1 day.
+	  nohup sh -c \"sleep 1d && CLOUDSDK_CONFIG=/tmp gcloud --quiet compute instances delete ${VM_ID} --zone=${machine_zone}\" > /dev/null &
+	else
+	  echo "❌ Failed to start the GitHub Actions runner service. Exiting ..."
+	  sh /usr/bin/gce_runner_shutdown.sh
+	fi
   "
 
   if $actions_preinstalled ; then

--- a/action.sh
+++ b/action.sh
@@ -295,7 +295,7 @@ function start_vm {
 	EOF
 
 	# See: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job
-	echo "ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/usr/bin/gce_runner_shutdown.sh" >.env
+	echo \"ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/usr/bin/gce_runner_shutdown.sh\" >.env
 	
 	gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=0 && \\
 	RUNNER_ALLOW_RUNASROOT=1 ./config.sh --url https://github.com/${GITHUB_REPOSITORY} --token ${RUNNER_TOKEN} --labels ${VM_ID} --unattended ${ephemeral_flag} --disableupdate && \\
@@ -303,15 +303,15 @@ function start_vm {
 	./svc.sh start
 
 	# Ensure actions.runner service is active
-	# if actions.runner is not active, it will shutdown the instance
+	#   it will shutdown the instance if actions.runner is not active
+	#   the instance will be shutdown in 1 day if actions runner is active even though the max workflow runtime is 3 days
 	if systemctl show actions.runner*${VM_ID}* -p ActiveState | grep 'ActiveState=' | head -1 | cut -f 2 -d '=' | grep 'active'; then
-	  echo "✅ Successfully started the GitHub Actions runner service."
-	  gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=1
-	  # self-shutdown in 1 day.
+	  echo \"✅ Successfully started the GitHub Actions runner service.\";
+	  gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=1;
 	  nohup sh -c \"sleep 1d && CLOUDSDK_CONFIG=/tmp gcloud --quiet compute instances delete ${VM_ID} --zone=${machine_zone}\" > /dev/null &
 	else
-	  echo "❌ Failed to start the GitHub Actions runner service. Exiting ..."
-	  sh /usr/bin/gce_runner_shutdown.sh
+	  echo \"❌ Failed to start the GitHub Actions runner service. Exiting ...\";
+	  sh /usr/bin/gce_runner_shutdown.sh;
 	fi
   "
 


### PR DESCRIPTION
Depends on #2 

# 原因

VM上でactions runnerが起動していることを示す `gh_ready=1`が、実際にはactions runnerが起動していないにもかかわらずついてしまい、現在の設定だと3日間滞留してしまうことで、利用可能インスタンス数を圧迫してしまっていた。

<details>

<summary><i>長いので折りたたみ</i></summary>

下記のように 
- `./svc.sh start` でactions runnerを起動し
- 成功したら`gh_ready=1`ラベルをつけて
- actions runnerが刺さったとしても、その後3日間建ったらVMを削除するプロセスを起動している
  - [別途job完了hookでshutdownをかけている](https://github.com/t2-auto/gce-github-runner/blob/d9fc97e78c8c99243437afaeabf3d1cfaabb194d/action.sh#L263)ので、これはjobがhungしている場合の処置
https://github.com/t2-auto/gce-github-runner/blob/d9fc97e78c8c99243437afaeabf3d1cfaabb194d/action.sh#L265-L270

が、

[下記のログ](https://console.cloud.google.com/logs/query;query=labels.%22compute.googleapis.com%2Fresource_name%22%3D%22gce-gh-runner-16808039869-1-create-gce-runner-for-test%22;cursorTimestamp=2025-08-07T14:57:11.264662283Z;startTime=2025-08-07T14:57:05.000Z;endTime=2025-08-07T14:58:08.000Z?hl=ja&inv=1&invt=Ab47qQ&project=t2-gha-poc)からわかるように

```
# systemd経由でactions.runnerを起動しようとしている
2025-08-07T14:57:06.092043428Z gce-gh-runner-16808039869-1-create-gce-runner-for-test google_metadata_script_runner[1421]: startup-script:
2025-08-07T14:57:06.092046153Z gce-gh-runner-16808039869-1-create-gce-runner-for-test google_metadata_script_runner[1421]: startup-script: /etc/systemd/system/actions.runner.t2-auto-Yatagarasu.gce-gh-runner-16808039869-1-create-gce-runner-for-test.service
...
# が、Segmentation faultでrunsvc.shが失敗
2025-08-07T14:57:06.093533442Z gce-gh-runner-16808039869-1-create-gce-runner-for-test runsvc.sh[4248]: /actions-runner/runsvc.sh: line 19: 4251 Segmentation fault ./externals/$nodever/bin/node ./bin/RunnerService.js
2025-08-07T14:57:06.094491697Z gce-gh-runner-16808039869-1-create-gce-runner-for-test systemd[1]: actions.runner.t2-auto-Yatagarasu.gce-gh-runner-16808039869-1-create-gce-runner-for-test.service: Main process exited, code=exited, status=139/n/a
2025-08-07T14:57:06.094569427Z gce-gh-runner-16808039869-1-create-gce-runner-for-test systemd[1]: actions.runner.t2-auto-Yatagarasu.gce-gh-runner-16808039869-1-create-gce-runner-for-test.service: Failed with result 'exit-code'.
2025-08-07T14:57:06.097750160Z gce-gh-runner-16808039869-1-create-gce-runner-for-test 

# serivceのstatusもfailedになっている
google_metadata_script_runner[1421]: startup-script: × actions.runner.t2-auto-Yatagarasu.gce-gh-runner-16808039869-1-create-gce-runner-for-test.service - GitHub Actions Runner (t2-auto-Yatagarasu.gce-gh-runner-16808039869-1-create-gce-runner-for-test)
2025-08-07T14:57:06.097752619Z gce-gh-runner-16808039869-1-create-gce-runner-for-test google_metadata_script_runner[1421]: startup-script: Loaded: loaded (/etc/systemd/system/actions.runner.t2-auto-Yatagarasu.gce-gh-runner-16808039869-1-create-gce-runner-for-test.service; enabled; vendor preset: enabled)
2025-08-07T14:57:06.097753780Z gce-gh-runner-16808039869-1-create-gce-runner-for-test google_metadata_script_runner[1421]: startup-script: Active: failed (Result: exit-code) since Thu 2025-08-07 14:57:06 UTC; 1ms ago
2025-08-07T14:57:06.097837373Z gce-gh-runner-16808039869-1-create-gce-runner-for-test google_metadata_script_runner[1421]: startup-script: Process: 4248 ExecStart=/actions-runner/runsvc.sh (code=exited, status=139)
2025-08-07T14:57:06.097838741Z gce-gh-runner-16808039869-1-create-gce-runner-for-test google_metadata_script_runner[1421]: startup-script: Main PID: 4248 (code=exited, status=139)
2025-08-07T14:57:06.097915998Z gce-gh-runner-16808039869-1-create-gce-runner-for-test google_metadata_script_runner[1421]: startup-script: CPU: 3ms
2025-08-07T14:57:06.097916942Z gce-gh-runner-16808039869-1-create-gce-runner-for-test google_metadata_script_runner[1421]: startup-script:
2025-08-07T14:57:06.097917491Z gce-gh-runner-16808039869-1-create-gce-runner-for-test google_metadata_script_runner[1421]: startup-script: Aug 07 14:57:06 gce-gh-runner-

# のに、なぜかserviceはStartedだと判定されている・・・・・・・
# (なんかFailed with result 'exit-code'みたいなログもでているが)
16808039869-1-create-gce-runner-for-test systemd[1]: Started GitHub Actions Runner (t2-auto-Yatagarasu.gce-gh-runner-16808039869-1-create-gce-runner-for-test).
...
16808039869-1-create-gce-runner-for-test systemd[1]: actions.runner.t2-auto-Yatagarasu.gce-gh-runner-16808039869-1-create-gce-runner-for-test.service: Main process exited, code=exited, status=139/n/a
2025-08-07T14:57:06.431270362Z gce-gh-runner-16808039869-1-create-gce-runner-for-test google_metadata_script_runner[1421]: startup-script: Aug 07 14:57:06 gce-gh-runner-16808039869-1-create-gce-runner-for-test systemd[1]: actions.runner.t2-auto-Yatagarasu.gce-gh-runner-16808039869-1-create-gce-runner-for-test.service: Failed with result 'exit-code'.
...

# 最終的にlabelを更新しに行っている・・・・・これが直接的な原因
2025-08-07T14:57:07.689579314Z gce-gh-runner-16808039869-1-create-gce-runner-for-test google_metadata_script_runner[1421]: startup-script: Updating labels of instance [gce-gh-runner-16808039869-1-create-gce-runner-for-test]...
```
</details>

# 修正

- 修正1: `svc.sh start`は信用できないので、実行後に、systemctlで実際のサービスの状態をチェックして
  - activeだったら
    - これまで通り `gh_ready=1` をつけて、job側が刺さっても、1日経ったら自然に死ぬように
    - 1日に短縮するPR自体は #2
  - activeじゃなかったら
    - 起動不全なので、自分自身をdelete
    - これで上流は起動失敗になるはず
- 修正2:
  - VM名にrepo名がはいっていなくて分かりづらかったので `gce-gh-runner-<repo>-<run_id>-<job_name>-<attempt>`とした
  - [VM名は63文字が最大](https://cloud.google.com/compute/docs/naming-resources?hl=ja#resource-name-format)なので、超えてしまうときはmd5の最初7文字をsuffixして63文字に収まるようにした

# テスト

actionの参照ブランチをこのブランチ`@fix-gh_ready-label-falsepositive`にしてテスト
https://github.com/t2-auto/apollo/actions/runs/16829686643/job/47689405196

※actions.runnerサービスの起動不全がテストできない(セグフォが狙って起こせない)のですが、正常ケースは通常通り通りました

# レビュー時のお願い

actions.runnerサービスの起動不全時のコードのチェックを入念にお願いします 🙇 
