### PR TITLE
TWS-1287: Shutdown when no job started in one hour

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -293,10 +293,20 @@ function start_vm {
 	# We tear down the machine by starting the systemd service that was registered by the startup script
 	systemctl start shutdown.service
 	EOF
+	chmod +x /usr/bin/gce_runner_shutdown.sh
+
+	cat <<-EOF > /usr/bin/gce_runner_job_started.sh
+	#!/bin/sh
+	set -x
+	mkdir -p /tmp
+	touch /tmp/gce_runner_job_started
+	EOF
+	chmod +x /usr/bin/gce_runner_job_started.sh
 
 	# See: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job
 	echo \"ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/usr/bin/gce_runner_shutdown.sh\" >.env
-	
+	echo \"ACTIONS_RUNNER_HOOK_JOB_STARTED=/usr/bin/gce_runner_job_started.sh\" >>.env
+
 	gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=0 && \\
 	RUNNER_ALLOW_RUNASROOT=1 ./config.sh --url https://github.com/${GITHUB_REPOSITORY} --token ${RUNNER_TOKEN} --labels ${VM_ID} --unattended ${ephemeral_flag} --disableupdate && \\
 	./svc.sh install && \\
@@ -304,11 +314,13 @@ function start_vm {
 
 	# Ensure actions.runner service is active
 	#   it will shutdown the instance if actions.runner is not active
+	#   the instance will be shutdown when no job has been started in 1 hour
 	#   the instance will be shutdown in 1 day if actions runner is active even though the max workflow runtime is 3 days
 	if systemctl show actions.runner* -p ActiveState | grep 'ActiveState=' | head -1 | cut -f 2 -d '=' | grep 'active'; then
 	  echo \"✅ Successfully started the GitHub Actions runner service.\";
 	  gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=1;
-	  nohup sh -c \"sleep 1d && CLOUDSDK_CONFIG=/tmp gcloud --quiet compute instances delete ${VM_ID} --zone=${machine_zone}\" > /dev/null &
+	  nohup sh -c \"sleep 1h && ([ -f  /tmp/gce_runner_job_started ] || systemctl start shutdown.service)\" > /dev/null &
+	  nohup sh -c \"sleep 3d && systemctl start shutdown.service\" > /dev/null &
 	else
 	  echo \"❌ Failed to start the GitHub Actions runner service. Exiting ...\";
 	  sh /usr/bin/gce_runner_shutdown.sh;

--- a/action.sh
+++ b/action.sh
@@ -305,7 +305,7 @@ function start_vm {
 	# Ensure actions.runner service is active
 	#   it will shutdown the instance if actions.runner is not active
 	#   the instance will be shutdown in 1 day if actions runner is active even though the max workflow runtime is 3 days
-	if systemctl show actions.runner*${VM_ID}* -p ActiveState | grep 'ActiveState=' | head -1 | cut -f 2 -d '=' | grep 'active'; then
+	if systemctl show actions.runner* -p ActiveState | grep 'ActiveState=' | head -1 | cut -f 2 -d '=' | grep 'active'; then
 	  echo \"✅ Successfully started the GitHub Actions runner service.\";
 	  gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=1;
 	  nohup sh -c \"sleep 1d && CLOUDSDK_CONFIG=/tmp gcloud --quiet compute instances delete ${VM_ID} --zone=${machine_zone}\" > /dev/null &

--- a/action.sh
+++ b/action.sh
@@ -180,7 +180,42 @@ function start_vm {
       jq -r .token)
   echo "✅ Successfully got the GitHub Runner registration token"
 
-  VM_ID="gce-gh-runner-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}"
+  # GCE VM label values requirements:
+  # - can contain only lowercase letters, numeric characters, underscores, and dashes
+  # - have a maximum length of 63 characters
+  # ref: https://cloud.google.com/compute/docs/labeling-resources#requirements
+  #
+  # Github's requirements:
+  # - username/organization name
+  #   - Max length: 39 characters
+  #   - All characters must be either a hyphen (-) or alphanumeric
+  # - repository name
+  #   - Max length: 100 code points
+  #   - All code points must be either a hyphen (-), an underscore (_), a period (.), 
+  #     or an ASCII alphanumeric code point
+  # ref: https://github.com/dead-claudia/github-limits
+  function truncate_to_label {
+    local in="${1}"
+    in="${in:0:63}"                              # ensure max length
+    in="${in//./_}"                              # replace '.' with '_'
+    in=$(tr '[:upper:]' '[:lower:]' <<< "${in}") # convert to lower
+    echo -n "${in}"
+  }
+  gh_repo_owner="$(truncate_to_label "${GITHUB_REPOSITORY_OWNER}")"
+  gh_repo="$(truncate_to_label "${GITHUB_REPOSITORY##*/}")"
+  gh_job="$(truncate_to_label "${GITHUB_JOB}")"
+  gh_run_id="${GITHUB_RUN_ID}"
+  gh_run_attempt="${GITHUB_RUN_ATTEMPT}"
+
+  VM_ID="gce-gh-runner-${gh_repo}-${GITHUB_RUN_ID}-${gh_job}-${GITHUB_RUN_ATTEMPT}"
+  if [ ${#VM_ID} -gt 63 ]; then
+    echo "VM_ID is too long: ${VM_ID}. It must be 63 characters or less."
+    VM_ID_PREFIX="${VM_ID:0:55}"
+    VM_ID_SUFFIX=$(echo ${VM_ID} | md5sum | cut -c 1-7)
+    VM_ID="${VM_ID_PREFIX}-${VM_ID_SUFFIX}"
+    echo "VM_ID is truncated: ${VM_ID}."
+  fi
+
   service_account_flag=$([[ -z "${runner_service_account}" ]] || echo "--service-account=${runner_service_account}")
   image_project_flag=$([[ -z "${image_project}" ]] || echo "--image-project=${image_project}")
   image_flag=$([[ -z "${image}" ]] || echo "--image=${image}")
@@ -300,31 +335,6 @@ function start_vm {
       $startup_script"
     fi
   fi
-  
-  # GCE VM label values requirements:
-  # - can contain only lowercase letters, numeric characters, underscores, and dashes
-  # - have a maximum length of 63 characters
-  # ref: https://cloud.google.com/compute/docs/labeling-resources#requirements
-  #
-  # Github's requirements:
-  # - username/organization name
-  #   - Max length: 39 characters
-  #   - All characters must be either a hyphen (-) or alphanumeric
-  # - repository name
-  #   - Max length: 100 code points
-  #   - All code points must be either a hyphen (-), an underscore (_), a period (.), 
-  #     or an ASCII alphanumeric code point
-  # ref: https://github.com/dead-claudia/github-limits
-  function truncate_to_label {
-    local in="${1}"
-    in="${in:0:63}"                              # ensure max length
-    in="${in//./_}"                              # replace '.' with '_'
-    in=$(tr '[:upper:]' '[:lower:]' <<< "${in}") # convert to lower
-    echo -n "${in}"
-  }
-  gh_repo_owner="$(truncate_to_label "${GITHUB_REPOSITORY_OWNER}")"
-  gh_repo="$(truncate_to_label "${GITHUB_REPOSITORY##*/}")"
-  gh_run_id="${GITHUB_RUN_ID}"
 
   gcloud compute instances create ${VM_ID} \
     --zone=${machine_zone} \
@@ -342,7 +352,7 @@ function start_vm {
     ${accelerator} \
     ${maintenance_policy_flag} \
     ${instance_termination_action_flag} \
-    --labels=gh_ready=0,gh_repo_owner="${gh_repo_owner}",gh_repo="${gh_repo}",gh_run_id="${gh_run_id}" \
+    --labels=gh_ready=0,gh_repo_owner="${gh_repo_owner}",gh_repo="${gh_repo}",gh_run_id="${gh_run_id}",gh_run_attempt="${gh_run_attempt}",gh_job="${gh_job}" \
     --metadata-from-file=shutdown-script=/tmp/shutdown_script.sh \
     --metadata=startup-script="$startup_script" \
     && echo "label=${VM_ID}" >> $GITHUB_OUTPUT

--- a/action.sh
+++ b/action.sh
@@ -296,13 +296,23 @@ function start_vm {
 
 	# See: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job
 	echo "ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/usr/bin/gce_runner_shutdown.sh" >.env
+	
 	gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=0 && \\
 	RUNNER_ALLOW_RUNASROOT=1 ./config.sh --url https://github.com/${GITHUB_REPOSITORY} --token ${RUNNER_TOKEN} --labels ${VM_ID} --unattended ${ephemeral_flag} --disableupdate && \\
 	./svc.sh install && \\
-	./svc.sh start && \\
-	gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=1
-	# self shutdown in 1 day.
-	nohup sh -c \"sleep 1d && CLOUDSDK_CONFIG=/tmp gcloud --quiet compute instances delete ${VM_ID} --zone=${machine_zone}\" > /dev/null &
+	./svc.sh start
+
+	# Ensure actions.runner service is active
+	# if actions.runner is not active, it will shutdown the instance
+	if systemctl show actions.runner*${VM_ID}* -p ActiveState | grep 'ActiveState=' | head -1 | cut -f 2 -d '=' | grep 'active'; then
+	  echo "✅ Successfully started the GitHub Actions runner service."
+	  gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=1
+	  # self-shutdown in 1 day.
+	  nohup sh -c \"sleep 1d && CLOUDSDK_CONFIG=/tmp gcloud --quiet compute instances delete ${VM_ID} --zone=${machine_zone}\" > /dev/null &
+	else
+	  echo "❌ Failed to start the GitHub Actions runner service. Exiting ..."
+	  sh /usr/bin/gce_runner_shutdown.sh
+	fi
   "
 
   if $actions_preinstalled ; then

--- a/action.sh
+++ b/action.sh
@@ -295,7 +295,7 @@ function start_vm {
 	EOF
 
 	# See: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job
-	echo "ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/usr/bin/gce_runner_shutdown.sh" >.env
+	echo \"ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/usr/bin/gce_runner_shutdown.sh\" >.env
 	
 	gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=0 && \\
 	RUNNER_ALLOW_RUNASROOT=1 ./config.sh --url https://github.com/${GITHUB_REPOSITORY} --token ${RUNNER_TOKEN} --labels ${VM_ID} --unattended ${ephemeral_flag} --disableupdate && \\
@@ -303,15 +303,15 @@ function start_vm {
 	./svc.sh start
 
 	# Ensure actions.runner service is active
-	# if actions.runner is not active, it will shutdown the instance
+	#   it will shutdown the instance if actions.runner is not active
+	#   the instance will be shutdown in 1 day if actions runner is active even though the max workflow runtime is 3 days
 	if systemctl show actions.runner*${VM_ID}* -p ActiveState | grep 'ActiveState=' | head -1 | cut -f 2 -d '=' | grep 'active'; then
-	  echo "✅ Successfully started the GitHub Actions runner service."
-	  gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=1
-	  # self-shutdown in 1 day.
+	  echo \"✅ Successfully started the GitHub Actions runner service.\";
+	  gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=1;
 	  nohup sh -c \"sleep 1d && CLOUDSDK_CONFIG=/tmp gcloud --quiet compute instances delete ${VM_ID} --zone=${machine_zone}\" > /dev/null &
 	else
-	  echo "❌ Failed to start the GitHub Actions runner service. Exiting ..."
-	  sh /usr/bin/gce_runner_shutdown.sh
+	  echo \"❌ Failed to start the GitHub Actions runner service. Exiting ...\";
+	  sh /usr/bin/gce_runner_shutdown.sh;
 	fi
   "
 


### PR DESCRIPTION
depends on #1 (このPRより先にマージする必要あり)

こんな感じで、gce作成が成功して、後続jobをself hoster runnerが吸う前にcancelされると、VMを削除するタイミングがなくなってしまう。

<img width="569" height="226" alt="image" src="https://github.com/user-attachments/assets/14b5bedd-202e-41a6-9765-8ed47cdf7bcc" />

ので、`ACTIONS_RUNNER_HOOK_JOB_STARTED` hookをつかって、jobが1時間以上スタートされない(このrunnerがjobを吸っていない)場合には、自分自身をshutdownするように修正

# To reviewers

please review only https://github.com/t2-auto/gce-github-runner/pull/3/commits/c3f90ae5897eb45b6055c696058548cf72771463