### PR TITLE
VM作成失敗時に進んでしまう&fallbackが効かない問題を修正

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -376,8 +376,9 @@ function start_vm {
     ${instance_termination_action_flag} \
     --labels=gh_ready=0,gh_repo_owner="${gh_repo_owner}",gh_repo="${gh_repo}",gh_run_id="${gh_run_id}",gh_run_attempt="${gh_run_attempt}",gh_job="${gh_job}" \
     --metadata-from-file=shutdown-script=/tmp/shutdown_script.sh \
-    --metadata=startup-script="$startup_script" \
-    && echo "label=${VM_ID}" >> $GITHUB_OUTPUT
+    --metadata=startup-script="$startup_script"
+
+  echo "label=${VM_ID}" >> $GITHUB_OUTPUT
 
   safety_off
   while (( i++ < 60 )); do

--- a/action.yml
+++ b/action.yml
@@ -101,6 +101,10 @@ inputs:
   boot_disk_type:
     description: "Boot disk type for the GCE instance (https://cloud.google.com/sdk/gcloud/reference/compute/disk-types/list)"
     required: false
+  fallback_runs_on_enabled:
+    description: "Whether to enable fallback to self-hosted runner. If this is set to true, the job will not fail even if the GCE runner fails to start."
+    default: false
+
 outputs:
   label:
     description: >-
@@ -111,6 +115,7 @@ runs:
   using: "composite"
   steps:
     - id: gce-github-runner-script
+      continue-on-error: ${{ inputs.fallback_runs_on_enabled == 'true' }}
       run: >
         ${{ github.action_path }}/action.sh
         --command=start


### PR DESCRIPTION
## VM作成失敗時に進んでしまう
VM作成処理は下記のようになっている

```bash
  safety_on  # (ここで set -eする)
...
  gcloud compute instances create ${VM_ID} \
    --zone=${machine_zone} \
    ....
    --metadata=startup-script="$startup_script" \
    && echo "label=${VM_ID}" >> $GITHUB_OUTPUT

  safety_off # (ここで set +eする)
  while (( i++ < 60 )); do
    GH_READY=$(gcloud compute instances describe ${VM_ID} --zone=${machine_zone} --format='json(labels)' | jq -r .labels.gh_ready)
```

が、[`gcloud compute instances create`が失敗しても`describe`に進んでしまっていた](https://github.com/t2-auto/gce-github-runner/blob/deep-learning-vm-iamge/action.sh#L361-L380)。VMは作成されていない&ジョブ全体は失敗するので、問題はないが不要にjobの時間がかかってしまう。

bashは　`&&` は条件式として評価され `set -e` は条件式の中では効かない。

```console
❯ bash <<-'EOT'
#!/bin/bash
set -e
not-found && echo ok
echo hello
EOT

bash: 行 3: not-found: command not found
hello

❯ bash <<-'EOT'
#!/bin/bash
set -e
not-found
echo hello
EOT

bash: 行 3: not-found: command not found
```

ので、 `&&` を使わないように修正

## 呼び出し側でfallbackが効かない

composite actionは展開されるだけぽくて、

```yaml
    - name: Create GCE instance for Github Actions runner
      id: create-runner
      uses: t2-auto/gce-github-runner@deep-learning-vm-iamge
      # fallbackが有効な時は失敗してもOK
      continue-on-error: ${{ steps.fallback-runs-on-enabled.outputs.resolved == 'true' }}
```
と書いても、[内部のstepが失敗するとそこでjobが失敗してしまう模様](https://github.com/t2-auto/Yatagarasu/actions/runs/18303624926/job/52199283638?pr=214)。

そこで、`continue-on-error`をcompsite actionに伝播させてちゃんと内部のステップで失敗しないようにする。具体的には`fallback_runs_on_enabled`というinputを渡し、それで内部の`continue-on-error`を指定する。
